### PR TITLE
Use `AsyncFn` in `TwirpRouter` and `GrpcRouter`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 authors = ["Thomas Pellissier-Tanon <thomas.pellissier-tanon@helsing.ai>"]
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.79"
+rust-version = "1.85"
 
 [workspace.dependencies]
 axum = { version = "0.8", default-features = false }

--- a/integration/src/server.rs
+++ b/integration/src/server.rs
@@ -42,7 +42,7 @@ impl IntegrationService for IntegrationServiceServicer {
 
     async fn test_client_stream(
         &self,
-        mut request: impl Stream<Item = Result<TestRequest, TwirpError>> + Send,
+        request: impl Stream<Item = Result<TestRequest, TwirpError>> + Send,
         ExtractBearerToken(bearer_token): ExtractBearerToken,
     ) -> Result<TestResponse, TwirpError> {
         if bearer_token != "password" {

--- a/server/src/codegen.rs
+++ b/server/src/codegen.rs
@@ -50,12 +50,19 @@ impl<S: Clone + Send + Sync + 'static, RS: Clone + Send + Sync + 'static> TwirpR
     pub fn route<
         I: ReflectMessage + Default,
         O: ReflectMessage,
-        F: Future<Output = Result<O, TwirpError>> + Send,
+        C: for<'a> AsyncFn(S, I, RequestParts, RS) -> Result<O, TwirpError>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
     >(
         mut self,
         path: &str,
-        call: impl (Fn(S, I, RequestParts, RS) -> F) + Clone + Send + Sync + 'static,
-    ) -> Self {
+        call: C,
+    ) -> Self
+    where
+        for<'a> <C as AsyncFnMut<(S, I, RequestParts, RS)>>::CallRefFuture<'a>: Send,
+    {
         let service = self.service.clone();
         self.router = self.router.route(
             path,
@@ -63,8 +70,8 @@ impl<S: Clone + Send + Sync + 'static, RS: Clone + Send + Sync + 'static> TwirpR
                 move |State(state): State<RS>, request: Request| async move {
                     let (parts, body) = request.with_limited_body().into_parts();
                     let content_type = ContentType::from_headers(&parts.headers)?;
-                    let request = parse_request(content_type, body).await?;
-                    let response = call(service, request, parts, state).await?;
+                    let request: I = parse_request(content_type, body).await?;
+                    let response = call.async_call((service, request, parts, state)).await?;
                     serialize_response(content_type, response)
                 },
             ),
@@ -215,13 +222,19 @@ impl<S: Clone + Send + Sync + 'static> GrpcRouter<S> {
     pub fn route<
         I: ReflectMessage + Default + 'static,
         O: ReflectMessage + 'static,
-        C: (Fn(S, I, RequestParts) -> F) + Clone + Send + Sync + 'static,
-        F: Future<Output = Result<O, TwirpError>> + Send + 'static,
+        C: for<'a> AsyncFn(S, I, RequestParts) -> Result<O, TwirpError>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
     >(
         mut self,
         path: &str,
         callback: C,
-    ) -> Self {
+    ) -> Self
+    where
+        for<'a> <C as AsyncFnMut<(S, I, RequestParts)>>::CallRefFuture<'a>: Send,
+    {
         let service = self.service.clone();
         self.router = self.router.route(
             path,
@@ -238,14 +251,20 @@ impl<S: Clone + Send + Sync + 'static> GrpcRouter<S> {
     pub fn route_server_streaming<
         I: ReflectMessage + Default + 'static,
         O: ReflectMessage + 'static,
-        C: (Fn(S, I, RequestParts) -> F) + Clone + Send + Sync + 'static,
-        F: Future<Output = Result<OS, TwirpError>> + Send + 'static,
+        C: for<'a> AsyncFn(S, I, RequestParts) -> Result<OS, TwirpError>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
         OS: Stream<Item = Result<O, TwirpError>> + Send + 'static,
     >(
         mut self,
         path: &str,
         callback: C,
-    ) -> Self {
+    ) -> Self
+    where
+        for<'a> <C as AsyncFnMut<(S, I, RequestParts)>>::CallRefFuture<'a>: Send,
+    {
         let service = self.service.clone();
         self.router = self.router.route(
             path,
@@ -262,13 +281,19 @@ impl<S: Clone + Send + Sync + 'static> GrpcRouter<S> {
     pub fn route_client_streaming<
         I: ReflectMessage + Default + 'static,
         O: ReflectMessage + 'static,
-        C: (Fn(S, GrpcClientStream<I>, RequestParts) -> F) + Clone + Send + Sync + 'static,
-        F: Future<Output = Result<O, TwirpError>> + Send + 'static,
+        C: for<'a> AsyncFn(S, GrpcClientStream<I>, RequestParts) -> Result<O, TwirpError>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
     >(
         mut self,
         path: &str,
         callback: C,
-    ) -> Self {
+    ) -> Self
+    where
+        for<'a> <C as AsyncFnMut<(S, GrpcClientStream<I>, RequestParts)>>::CallRefFuture<'a>: Send,
+    {
         let service = self.service.clone();
         self.router = self.router.route(
             path,
@@ -285,14 +310,20 @@ impl<S: Clone + Send + Sync + 'static> GrpcRouter<S> {
     pub fn route_streaming<
         I: ReflectMessage + Default + 'static,
         O: ReflectMessage + 'static,
-        C: (Fn(S, GrpcClientStream<I>, RequestParts) -> F) + Clone + Send + Sync + 'static,
-        F: Future<Output = Result<OS, TwirpError>> + Send + 'static,
+        C: for<'a> AsyncFn(S, GrpcClientStream<I>, RequestParts) -> Result<OS, TwirpError>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
         OS: Stream<Item = Result<O, TwirpError>> + Send + 'static,
     >(
         mut self,
         path: &str,
         callback: C,
-    ) -> Self {
+    ) -> Self
+    where
+        for<'a> <C as AsyncFnMut<(S, GrpcClientStream<I>, RequestParts)>>::CallRefFuture<'a>: Send,
+    {
         let service = self.service.clone();
         self.router = self.router.route(
             path,
@@ -322,17 +353,22 @@ impl<
         S: Clone + Send + Sync + 'static,
         I: ReflectMessage + Default + 'static,
         O: ReflectMessage + 'static,
-        C: (Fn(S, I, RequestParts) -> F) + Clone + Send + 'static,
-        F: Future<Output = Result<O, TwirpError>> + Send + 'static,
+        C: for<'a> AsyncFn(S, I, RequestParts) -> Result<O, TwirpError> + Clone + Send + 'static,
     > tonic::server::UnaryService<I> for GrpcService<S, C>
+where
+    for<'a> <C as AsyncFnMut<(S, I, RequestParts)>>::CallRefFuture<'a>: Send,
 {
     type Response = O;
     type Future = TonicResponseFuture<O>;
 
     fn call(&mut self, request: tonic::Request<I>) -> Self::Future {
         let (request, parts) = grpc_to_twirp_request(request);
-        let result_future = (self.callback)(self.service.clone(), request, parts);
-        Box::pin(async move { Ok(tonic::Response::new(result_future.await?)) })
+        let service = self.service.clone();
+        let callback = self.callback.clone();
+        Box::pin(async move {
+            let result_future = callback.async_call((service, request, parts));
+            Ok(tonic::Response::new(result_future.await?))
+        })
     }
 }
 
@@ -341,10 +377,11 @@ impl<
         S: Clone + Send + Sync + 'static,
         I: ReflectMessage + Default + 'static,
         O: ReflectMessage + 'static,
-        C: (Fn(S, I, RequestParts) -> F) + Clone + Send + 'static,
-        F: Future<Output = Result<OS, TwirpError>> + Send + 'static,
+        C: for<'a> AsyncFn(S, I, RequestParts) -> Result<OS, TwirpError> + Clone + Send + 'static,
         OS: Stream<Item = Result<O, TwirpError>> + Send + 'static,
     > tonic::server::ServerStreamingService<I> for GrpcService<S, C>
+where
+    for<'a> <C as AsyncFnMut<(S, I, RequestParts)>>::CallRefFuture<'a>: Send,
 {
     type Response = O;
     type ResponseStream = Pin<Box<dyn Stream<Item = Result<O, tonic::Status>> + Send>>;
@@ -352,8 +389,10 @@ impl<
 
     fn call(&mut self, request: tonic::Request<I>) -> Self::Future {
         let (request, parts) = grpc_to_twirp_request(request);
-        let result_future = (self.callback)(self.service.clone(), request, parts);
+        let service = self.service.clone();
+        let callback = self.callback.clone();
         Box::pin(async move {
+            let result_future = callback.async_call((service, request, parts));
             Ok(tonic::Response::new(
                 Box::pin(result_future.await?.map(|item| Ok(item?))) as Self::ResponseStream,
             ))
@@ -366,9 +405,13 @@ impl<
         S: Clone + Send + Sync + 'static,
         I: ReflectMessage + Default + 'static,
         O: ReflectMessage + 'static,
-        C: (Fn(S, GrpcClientStream<I>, RequestParts) -> F) + Clone + Send + 'static,
-        F: Future<Output = Result<O, TwirpError>> + Send + 'static,
+        C: for<'a> AsyncFn(S, GrpcClientStream<I>, RequestParts) -> Result<O, TwirpError>
+            + Clone
+            + Send
+            + 'static,
     > tonic::server::ClientStreamingService<I> for GrpcService<S, C>
+where
+    for<'a> <C as AsyncFnMut<(S, GrpcClientStream<I>, RequestParts)>>::CallRefFuture<'a>: Send,
 {
     type Response = O;
     type Future = TonicResponseFuture<Self::Response>;
@@ -376,8 +419,12 @@ impl<
     fn call(&mut self, request: tonic::Request<tonic::Streaming<I>>) -> Self::Future {
         let (request, parts) = grpc_to_twirp_request(request);
         let request = GrpcClientStream { stream: request };
-        let result_future = (self.callback)(self.service.clone(), request, parts);
-        Box::pin(async move { Ok(tonic::Response::new(result_future.await?)) })
+        let service = self.service.clone();
+        let callback = self.callback.clone();
+        Box::pin(async move {
+            let result_future = callback.async_call((service, request, parts));
+            Ok(tonic::Response::new(result_future.await?))
+        })
     }
 }
 
@@ -386,10 +433,14 @@ impl<
         S: Clone + Send + Sync + 'static,
         I: ReflectMessage + Default + 'static,
         O: ReflectMessage + 'static,
-        C: (Fn(S, GrpcClientStream<I>, RequestParts) -> F) + Clone + Send + 'static,
-        F: Future<Output = Result<OS, TwirpError>> + Send + 'static,
+        C: for<'a> AsyncFn(S, GrpcClientStream<I>, RequestParts) -> Result<OS, TwirpError>
+            + Clone
+            + Send
+            + 'static,
         OS: Stream<Item = Result<O, TwirpError>> + Send + 'static,
     > tonic::server::StreamingService<I> for GrpcService<S, C>
+where
+    for<'a> <C as AsyncFnMut<(S, GrpcClientStream<I>, RequestParts)>>::CallRefFuture<'a>: Send,
 {
     type Response = O;
     type ResponseStream = Pin<Box<dyn Stream<Item = Result<O, tonic::Status>> + Send>>;
@@ -398,8 +449,10 @@ impl<
     fn call(&mut self, request: tonic::Request<tonic::Streaming<I>>) -> Self::Future {
         let (request, parts) = grpc_to_twirp_request(request);
         let request = GrpcClientStream { stream: request };
-        let result_future = (self.callback)(self.service.clone(), request, parts);
+        let service = self.service.clone();
+        let callback = self.callback.clone();
         Box::pin(async move {
+            let result_future = callback.async_call((service, request, parts));
             Ok(tonic::Response::new(
                 Box::pin(result_future.await?.map(|item| Ok(item?))) as Self::ResponseStream,
             ))
@@ -517,7 +570,7 @@ mod tests {
         let router = TwirpRouter::new(())
             .route(
                 "/package.MyService/MyMethod",
-                |(), request: MyMessage, _, _| async move { Ok(request) },
+                async |(), request: MyMessage, _, _| Ok(request),
             )
             .build();
         let response = router
@@ -543,7 +596,7 @@ mod tests {
         let router = TwirpRouter::new(())
             .route(
                 "/package.MyService/MyMethod",
-                |(), request: MyMessage, _, _| async move { Ok(request) },
+                async |(), request: MyMessage, _, _| Ok(request),
             )
             .build();
         let response = router
@@ -570,7 +623,7 @@ mod tests {
         let router = TwirpRouter::new(())
             .route(
                 "/package.MyService/MyMethod",
-                |(), request: MyMessage, _, _| async move { Ok(request) },
+                async |(), request: MyMessage, _, _| Ok(request),
             )
             .build();
         let response = router
@@ -597,7 +650,7 @@ mod tests {
         let router = TwirpRouter::new(())
             .route(
                 "/package.MyService/MyMethod",
-                |(), request: MyMessage, _, _| async move { Ok(request) },
+                async |(), request: MyMessage, _, _| Ok(request),
             )
             .build();
         let response = router
@@ -624,7 +677,7 @@ mod tests {
         let router = TwirpRouter::new(())
             .route(
                 "/package.MyService/MyMethod",
-                |(), request: MyMessage, _, _| async move { Ok(request) },
+                async |(), request: MyMessage, _, _| Ok(request),
             )
             .build();
         let response = router
@@ -651,7 +704,7 @@ mod tests {
         let router = TwirpRouter::new(())
             .route(
                 "/package.MyService/MyMethod",
-                |(), request: MyMessage, _, _| async move { Ok(request) },
+                async |(), request: MyMessage, _, _| Ok(request),
             )
             .build();
         let response = router
@@ -679,7 +732,7 @@ mod tests {
         let router = GrpcRouter::new(())
             .route(
                 "/package.MyService/MyMethod",
-                |(), request: MyMessage, _| async move { Ok(request) },
+                async |(), request: MyMessage, _| Ok(request),
             )
             .build();
         let path = PathAndQuery::from_static("/package.MyService/MyMethod");
@@ -701,7 +754,7 @@ mod tests {
         let router = GrpcRouter::new(())
             .route(
                 "/package.MyService/MyMethod",
-                |(), _: MyMessage, _| async move {
+                async |(), _: MyMessage, _| {
                     Err::<MyMessage, _>(TwirpError::not_found("foo not found"))
                 },
             )

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,6 +5,8 @@
     html_logo_url = "https://raw.githubusercontent.com/helsing-ai/twurst/main/docs/img/twurst.png"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![feature(async_fn_traits)]
+#![feature(unboxed_closures)]
 
 #[doc(hidden)]
 pub mod codegen;


### PR DESCRIPTION
Closes #54 

> This PR updates the `TwirpRouter::route` and `GrpcRouter::route*` methods to use `AsyncFn` simplifying the type constraints.