### PR TITLE
Add TwirpBuilder::skip_prost_reflect() for custom out_dir support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "eyre",
  "prost",
  "prost-reflect",
+ "prost-reflect-build",
  "prost-types",
  "tokio",
  "tokio-stream",

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -29,6 +29,7 @@ pub struct TwirpBuilder {
     config: Config,
     generator: TwirpServiceGenerator,
     type_name_domain: Option<String>,
+    skip_prost_reflect: bool,
 }
 
 impl TwirpBuilder {
@@ -43,6 +44,7 @@ impl TwirpBuilder {
             config,
             generator: TwirpServiceGenerator::new(),
             type_name_domain: None,
+            skip_prost_reflect: false,
         }
     }
 
@@ -211,6 +213,17 @@ impl TwirpBuilder {
         self
     }
 
+    /// Skips the built-in prost-reflect configuration and file patching.
+    ///
+    /// When enabled, callers are responsible for configuring prost-reflect
+    /// on the [`Config`] before passing it to [`from_prost`](Self::from_prost).
+    /// This is useful when using a custom `out_dir` or when using
+    /// `descriptor_pool` mode instead of `file_descriptor_set_bytes`.
+    pub fn skip_prost_reflect(mut self) -> Self {
+        self.skip_prost_reflect = true;
+        self
+    }
+
     /// Customizes the type name domain.
     ///
     /// By default, 'type.googleapis.com' is used.
@@ -245,9 +258,11 @@ impl TwirpBuilder {
             .service_generator(Box::new(self.generator));
 
         // We configure with prost reflect
-        prost_reflect_build::Builder::new()
-            .file_descriptor_set_bytes("self::FILE_DESCRIPTOR_SET_BYTES")
-            .configure(&mut self.config, protos, includes)?;
+        if !self.skip_prost_reflect {
+            prost_reflect_build::Builder::new()
+                .file_descriptor_set_bytes("self::FILE_DESCRIPTOR_SET_BYTES")
+                .configure(&mut self.config, protos, includes)?;
+        }
 
         // We do the build itself while saving the list of modules
         let config = self.config.skip_protoc_run();
@@ -262,14 +277,16 @@ impl TwirpBuilder {
         config.compile_fds(file_descriptor_set)?;
 
         // We add the file descriptor to every file to make reflection work automatically
-        for module in modules {
-            let file_path = Path::new(&out_dir).join(module.to_file_name_or("_"));
-            if !file_path.exists() {
-                continue; // We ignore not built files
+        if !self.skip_prost_reflect {
+            for module in modules {
+                let file_path = Path::new(&out_dir).join(module.to_file_name_or("_"));
+                if !file_path.exists() {
+                    continue; // We ignore not built files
+                }
+                let original_content = fs::read_to_string(&file_path)?;
+                let modified_content = add_use_file_descriptor_to_file(&original_content)?;
+                fs::write(&file_path, &modified_content)?;
             }
-            let original_content = fs::read_to_string(&file_path)?;
-            let modified_content = add_use_file_descriptor_to_file(&original_content)?;
-            fs::write(&file_path, &modified_content)?;
         }
 
         Ok(())

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -24,3 +24,4 @@ tower-http = { workspace = true, features = ["auth", "cors"] }
 [build-dependencies]
 twurst-build.path = "../build"
 tonic-prost-build.workspace = true
+prost-reflect-build.workspace = true

--- a/integration/build.rs
+++ b/integration/build.rs
@@ -10,10 +10,26 @@ fn main() -> std::io::Result<()> {
         .compile_protos(&["integration.proto"], &["."])?;
 
     // Custom out dir to not override Twirp
-    let dir = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("tonic");
-    fs::create_dir_all(&dir)?;
+    let tonic_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("tonic");
+    fs::create_dir_all(&tonic_dir)?;
     tonic_prost_build::configure()
-        .out_dir(dir)
+        .out_dir(&tonic_dir)
         .type_attribute("Int", "#[allow(dead_code)]") // to make clippy happy
-        .compile_protos(&["integration.proto"], &["."])
+        .compile_protos(&["integration.proto"], &["."])?;
+
+    // Custom out dir with skip_prost_reflect: caller configures prost-reflect externally
+    let custom_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("custom");
+    fs::create_dir_all(&custom_dir)?;
+    let mut custom_config = twurst_build::prost::Config::new();
+    custom_config.out_dir(&custom_dir);
+    prost_reflect_build::Builder::new()
+        .file_descriptor_set_path(custom_dir.join("file_descriptor_set.bin"))
+        .descriptor_pool("crate::custom_out_dir::DESCRIPTOR_POOL")
+        .configure(&mut custom_config, &["integration.proto"], &["."])?;
+    twurst_build::TwirpBuilder::from_prost(custom_config)
+        .skip_prost_reflect()
+        .with_server()
+        .compile_protos(&["integration.proto"], &["."])?;
+
+    Ok(())
 }

--- a/integration/src/lib.rs
+++ b/integration/src/lib.rs
@@ -2,5 +2,21 @@ pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/integration.rs"));
 }
 
+/// Generated with a custom `out_dir` and `skip_prost_reflect`, exercising the
+/// code path where callers configure prost-reflect externally.
+pub mod custom_out_dir {
+    use prost_reflect::DescriptorPool;
+    use std::sync::LazyLock;
+
+    static DESCRIPTOR_POOL: LazyLock<DescriptorPool> = LazyLock::new(|| {
+        DescriptorPool::decode(
+            include_bytes!(concat!(env!("OUT_DIR"), "/custom/file_descriptor_set.bin")).as_ref(),
+        )
+        .expect("failed to decode descriptor pool")
+    });
+
+    include!(concat!(env!("OUT_DIR"), "/custom/integration.rs"));
+}
+
 pub mod client;
 pub mod server;


### PR DESCRIPTION
## Summary

- Add `TwirpBuilder::skip_prost_reflect()` so callers can skip the built-in prost-reflect configuration and file patching
- Callers who need a custom `out_dir` can configure prost-reflect externally (e.g. using `descriptor_pool` mode), avoiding the hardcoded `$OUT_DIR` file-patching issue
- Add integration test exercising `skip_prost_reflect` with a custom `out_dir` and `descriptor_pool` mode

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)