### PR TITLE
chore: relax version constraint on tower-http

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 tower-service = "0.3.3"
 tower = "0.5.3"
-tower-http = "0.7.0"
+tower-http = ">=0.6.11, <0.8"
 tracing = "0.1.44"
 trait-variant = "0.1.2"
 twurst-error = { path = "error", version = "0.3.0" }


### PR DESCRIPTION
twurst only uses `tower_http::auth::{AddAuthorization, AddAuthorizationLayer}` and `tower_http::cors::{CorsLayer, Any}`.

The 0.7.0 breaking changes affect `compression`, `follow-redirect`, `trace/classify` (gRPC), `services` (trailing-slash files), and removed no-op features (`tokio, async-compression`) — none touch the auth or cors APIs used here.

Verified:
- `cargo clippy --workspace --all-targets` clean with tower-http 0.6.11
- `cargo clippy --workspace --all-targets` clean with tower-http 0.7.0 (picked automatically as latest)