### PR TITLE
fix: inject DESCRIPTOR_POOL into nested message modules

### DIFF
--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -620,3 +620,26 @@ fn quote_comments(comments: &Comments) -> Vec<TokenStream> {
         .map(|c| quote! { #[doc = #c] })
         .collect::<Vec<_>>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injects_descriptor_pool_into_nested_modules() {
+        let input = "mod a { mod b { mod c { } } }";
+        let output = add_use_file_descriptor_to_file(input).unwrap();
+
+        assert_eq!(
+            output.matches("use super::DESCRIPTOR_POOL;").count(),
+            3,
+            "expected `use super::DESCRIPTOR_POOL;` in both nested modules, got:\n{output}"
+        );
+
+        assert_eq!(
+            output.matches("static DESCRIPTOR_POOL").count(),
+            1,
+            "expected a single DESCRIPTOR_POOL declaration, got:\n{output}"
+        );
+    }
+}

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -313,6 +313,7 @@ fn add_use_file_descriptor_to_nested_modules(items: &mut Vec<Item>) {
                     use super::DESCRIPTOR_POOL;
                 },
             );
+            add_use_file_descriptor_to_nested_modules(module_content);
         }
     }
 }


### PR DESCRIPTION
**Description:**

`twurst-build` (0.3.5) fails to compile protos that contain messages nested 2+ levels deep. Such messages generate a `mod` inside a `mod`, but the `use super::DESCRIPTOR_POOL;` import is only injected into the first level of nesting, the inner modules never get it, so `#[prost_reflect(descriptor_pool = "self::DESCRIPTOR_POOL")]` fails to resolve.

**Reproduction:**

```proto
syntax = "proto3";

package poc.nested;

message Outer {
  string name = 1;

  message Middle {
    string label = 1;

    message Inner {
      int32 value = 1;
    }
  }
}
```
```
error[E0425]: cannot find value `DESCRIPTOR_POOL` in module `self`
  --> poc.nested.rs:27:18
   |
27 |         #[derive(::prost_reflect::ReflectMessage)]
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `self`
   |
   = note: this error originates in the derive macro `::prost_reflect::ReflectMessage` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing this static
   |
25 +         use crate::nested::DESCRIPTOR_POOL;
   |
```

The generated `pub mod outer` gets `use super::DESCRIPTOR_POOL;`, but the nested `pub mod middle` (containing `Inner`) does not — that's where compilation fails.
